### PR TITLE
Referência de múltiplas posições

### DIFF
--- a/include/aarray.ch
+++ b/include/aarray.ch
@@ -102,6 +102,7 @@
 	#IFNDEF __HARBOUR__
 		#include "shash.ch" 
 
+		#xtranslate \[\#<k>,<l> => :Get(<k>)\[\#<l>
 		#xtranslate \[\#<k>\] := <v>        => :Set(<k>,<v>)
 		#xtranslate \[\#<k>\]               => :Get(<k>)
 		#xtranslate Array(\#)               => SHash():New()


### PR DESCRIPTION
A linha adicionada permitirá que comandos como

oArray[#"id1", "id2", "id3"]

funcionem e sejam convertidos para

oArray:Get("id1"):Get("id2"):Get("id3")

devido à reaplicação do .ch sobre o fonte que o compilador faz até que não exista nada a ser substituído.

Inclusive um comando neste formato:

oArray[#"id1", "id2", "id3"] := "novovalor"

funcionaria, sendo convertido para

oArray:Get("id1"):Get("id2"):Set("id3", "novovalor")
